### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:edge
+
+COPY ./ /tmp
+
+WORKDIR /tmp
+
+RUN apk update \
+  && apk add --no-cache ca-certificates \
+                        libressl \
+                        llvm-libunwind \
+  && apk add --no-cache --virtual .build-rust \
+    rust \
+    cargo \
+    libressl-dev \
+  && cargo build --release \
+  && mv target/release/iptoasn-webservice /usr/bin/iptoasn-webservice \
+  && rm -rf  ~/.cargo \
+            /var/cache/apk/* \
+            /tmp/* \
+  && apk del .build-rust
+
+RUN adduser -D app
+USER app
+
+ENTRYPOINT /usr/bin/iptoasn-webservice --listen 0.0.0.0:10000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,13 @@ RUN apk update \
     rust \
     cargo \
     libressl-dev \
+  \
   && cargo build --release \
+  && strip target/release/iptoasn-webservice \
   && mv target/release/iptoasn-webservice /usr/bin/iptoasn-webservice \
+  && mv docker/iptoasn-entrypoint.sh /iptoasn-entrypoint.sh \
+  && chmod +x /iptoasn-entrypoint.sh \
+  \
   && rm -rf  ~/.cargo \
             /var/cache/apk/* \
             /tmp/* \
@@ -22,4 +27,4 @@ RUN apk update \
 RUN adduser -D app
 USER app
 
-ENTRYPOINT /usr/bin/iptoasn-webservice --listen 0.0.0.0:10000
+ENTRYPOINT ["/iptoasn-entrypoint.sh"]

--- a/docker/iptoasn-entrypoint.sh
+++ b/docker/iptoasn-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+DEFAULT_PORT='53661'
+DEFAULT_DBURL='https://iptoasn.com/data/ip2asn-combined.tsv.gz'
+
+if [ $IPTOASN_PORT ] || [ $IPTOASN_DBURL]; then
+  if ! [ $IPTOASN_PORT ]; then
+    IPTOASN_PORT=$DEFAULT_PORT
+  fi
+
+  if ! [ $IPTOASN_DBURL ]; then
+    IPTOASN_DBURL=$DEFAULT_DBURL
+  fi
+
+  exec /usr/bin/iptoasn-webservice --listen 0.0.0.0:"$IPTOASN_PORT" --dburl "$IPTOASN_DBURL"
+else
+  exec /usr/bin/iptoasn-webservice $@
+fi


### PR DESCRIPTION
You can now run `iptoasn-webservice` using docker only. It's based on the `alpine:edge` image and is 11MB unpacked. Runs service as a regular user. Entrypoint script included.

Hope this work will be useful.

## How to use

Assume you are in the repo's root folder:

```
docker build -t iptoasn -f docker/Dockerfile .
docker run -itd --name my-iptoasn -p 80:53661 iptoasn
...wait for a while
curl 127.0.0.1:80/v1/as/ip/8.8.8.8
```
### Setting service parameters

Listen port and database URL can be specified by environment variables:

```
docker run -itd --name my-iptoasn -e IPTOASN_PORT=10000 -e IPTOASN_DBURL='http://your-database-url.com' -p 80:10000 iptoasn
```

### Use as a binary

```
docker run -it --rm iptoasn --help
```

Any feedback or suggestions are welcome!