### PR TITLE
Fix dockerized iptoasn-webservice

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,14 @@
-FROM alpine:edge
+FROM alpine:3.7
 
-COPY ./ /tmp
+COPY Cargo.* /tmp/iptoasn/
+COPY src /tmp/iptoasn/src
 
-WORKDIR /tmp
+WORKDIR /tmp/iptoasn
 
-RUN apk update \
-  && apk add --no-cache ca-certificates \
-                        libressl \
-                        llvm-libunwind \
+RUN apk add --update --no-cache ca-certificates \
+                                libressl \
+                                llvm-libunwind \
+                                libgcc \
   && apk add --no-cache --virtual .build-rust \
     rust \
     cargo \
@@ -16,15 +17,16 @@ RUN apk update \
   && cargo build --release \
   && strip target/release/iptoasn-webservice \
   && mv target/release/iptoasn-webservice /usr/bin/iptoasn-webservice \
-  && mv docker/iptoasn-entrypoint.sh /iptoasn-entrypoint.sh \
-  && chmod +x /iptoasn-entrypoint.sh \
+  && adduser -D app \
   \
+  && apk del .build-rust \
   && rm -rf  ~/.cargo \
             /var/cache/apk/* \
-            /tmp/* \
-  && apk del .build-rust
+            /tmp/*
 
-RUN adduser -D app
+COPY docker/iptoasn-entrypoint.sh /iptoasn-entrypoint.sh
+RUN chmod +x /iptoasn-entrypoint.sh
+
 USER app
 
 ENTRYPOINT ["/iptoasn-entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,34 @@
+## How to use
+
+Assume you are in the repo's root folder:
+
+```bash
+docker build -t iptoasn -f docker/Dockerfile .
+docker run -itd \
+           --name my-iptoasn \
+           -p 80:53661 \
+           iptoasn
+```
+
+Wait while iptoasn is downloading data, and then you can do `curl` requests as you used to:
+```bash
+curl 127.0.0.1:80/v1/as/ip/8.8.8.8
+```
+
+### Setting service parameters
+
+Listen port and database URL can be specified by environment variables:
+```bash
+docker run -itd \
+           --name my-iptoasn \
+           -e IPTOASN_PORT=10000 \
+           -e IPTOASN_DBURL='http://your-database-url.com' \
+           -p 80:10000 \
+           iptoasn
+```
+
+### Use as a binary
+
+```bash
+docker run -it --rm iptoasn --help
+```


### PR DESCRIPTION
At some point dockerized version build started to fail, because `libressl` package version is 2.7 in `alpine:edge` image (`openssl` crate requires 2.5-2.6) and the container didn't start, because `libgcc` package is not installed.

Briefly, this PR will do the following:
* Downgrade image from `alpine:edge` to `alpine:3.7`, where libressl has version 2.6 and almost everything is more robust.
* Add `libgcc` package.
* Copy to the container only required files, so `.git` folder and friends won't mess around.
* Add readme file.

In addition, we can move `Dockerfile` to the root of the project, so automated image building could be leveraged to push new image on commit to hub.docker.com.

I'm open to any suggestions.