### PR TITLE
docker: fix alpine version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:test
+FROM alpine:3.13.1
 
 COPY Cargo.* /tmp/iptoasn/
 COPY src /tmp/iptoasn/src


### PR DESCRIPTION
Hello,

I have changed the docker alpinelinux version to `3.13.1` as `test` version does not exist.

Cheers!