### PR TITLE
Update Alpine to fix Cargo issue caused by textwrap

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13.1
+FROM alpine:3.16.2
 
 COPY Cargo.* /tmp/iptoasn/
 COPY src /tmp/iptoasn/src


### PR DESCRIPTION
```
#9 28.11 error: failed to parse manifest at `/root/.cargo/registry/src/github.com-1ecc6299db9ec823/textwrap-0.15.1/Cargo.toml`
#9 28.11
#9 28.11 Caused by:
#9 28.11   failed to parse the `edition` key
#9 28.11
#9 28.11 Caused by:
#9 28.11   this version of Cargo is older than the `2021` edition, and only supports `2015` and `2018` editions.
```

The Alpine version used within the Dockerfile had an old version of Rust embedded. After upgrading to 3.16.2 this issue is fixed