### PR TITLE
Update versions for Alpine, hyper-rustls, and tokio.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iptoasn-webservice"
 description = "API server for iptoasn.com"
-version = "0.2.5"
+version = "0.2.6"
 homepage = "https://iptoasn.com"
 repository = "https://github.com/jedisct1/iptoasn-webservice"
 keywords = ["ip", "asn", "bgp"]
@@ -16,8 +16,8 @@ horrorshow = "0.8"
 hyper = { version = "1.6", features = ["server", "http1", "client"] }
 hyper-util = { version = "0.1", features = ["tokio", "client", "http1"] }
 http-body-util = "0.1"
-tokio = { version = "1.44", features = ["full"] }
-hyper-rustls = { version = "0.26", features = ["http1", "http2", "webpki-roots"] }
+tokio = { version = "1.45", features = ["full"] }
+hyper-rustls = { version = "0.27", features = ["http1", "http2", "webpki-roots"] }
 log = "0.4"
 env_logger = "0.11"
 serde = { version = "1.0", features = ["derive"] }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.7
+FROM alpine:3.22.0
 
 COPY Cargo.* /tmp/iptoasn/
 COPY src /tmp/iptoasn/src


### PR DESCRIPTION
I do not see an issue tracker so I am submitting this patch with updated versions that somewhat worked for me.

The [main iptoasn.com page](https://iptoasn.com/) works for me, but the `tsv` files do not work. I also got two others to confirm this so it is not just me.

The rust script seems to keep [ip2asn-combined.tsv.gz](https://iptoasn.com/data/ip2asn-combined.tsv.gz) loaded in RAM and pulls every hour by default. When the file is not found, the script breaks even if it had a valid `tsv` file previously.

I mistakenly thought the above issues were an issue with my docker or rust configuration and I found another problem. Builds did not work for me on Alpine 3.17.7 because the cargo version available ran into the`"the package iptoasn-webserver depends on env_logger, with features: anstream but env_logger does not have these features.` error similar to this [mdBook issue](https://github.com/rust-lang/mdBook/issues/2318). Using a newer version of rust and cargo was able to solve the issue. I believe this patch fixes this rust issue, but I am not 100% sure because of the other issues.

On a low-resource machine, I also added `-j 1`  to the Dockerfile to avoid crashes. This is just a note and I did not include this as a patch because most people likely have stronger machines.

`cargo build -j 1 --release`

I really appreciate <https://iptoasn.com/> and I previously gave a shout out [in this blog post](https://www.fsf.org/bulletin/2024/fall/fsf-sysops-cleaning-up-the-internet). I found iptoasn to be an incredibly useful tool to identify patterns of abuse and preemptively block cloud providers that were likely to cause future outages. iptoasn greatly helped me with preparing abuse reports.

I also wrote some helper scripts to help me parse a list of IP addresses and build descriptive firewall rules and commands for iptables, UFW, and shorewall. I would be happy to share these as a different patch if you are interested.