### PR TITLE
Fix missing whitespace before closing square bracket in iptoasn-entrypoint.sh

### DIFF
--- a/docker/iptoasn-entrypoint.sh
+++ b/docker/iptoasn-entrypoint.sh
@@ -3,7 +3,7 @@
 DEFAULT_PORT='53661'
 DEFAULT_DBURL='https://iptoasn.com/data/ip2asn-combined.tsv.gz'
 
-if [ $IPTOASN_PORT ] || [ $IPTOASN_DBURL]; then
+if [ $IPTOASN_PORT ] || [ $IPTOASN_DBURL ]; then
   if ! [ $IPTOASN_PORT ]; then
     IPTOASN_PORT=$DEFAULT_PORT
   fi


### PR DESCRIPTION
Hi. This pull request fixes a small Shell Script syntax error in `iptoasn-entrypoint.sh`.
