### PR TITLE
[feat] self-lookup if no ip provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ cargo build --release
 
 ## API Usage
 
+### Routes
+
+- `/v1/as/ip/<ip address>`
+  - Lookup provided IP address
+- `/v1/as/ip`
+  - Lookup requester's IP address, prioritized as X-Real-IP > X-Forwarded-For > Request IP
+
 ### JSON Response
 
 ```sh


### PR DESCRIPTION
This PR adds self-lookup for the `/v1/as/ip` route. The HTTP headers for X-Real-IP and X-Forwarded-For (first entry) take priority over the actual request IP. This opens up the use cases, as it simplifies retrieval of the public IP address and geolocation/ASN.
Personally I previously used a similiar approach to retrieve data needed to determine the best download server for a client, with geolocation for location proximity and ASN to filter for specific routing limitations (eg. DTAG -> CF).