### PR TITLE
Improve Memory Use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.3", features = ["macros", "formatting"] }
 http = "1.3"
+tikv-jemallocator = "0.6"
 
 [features]
 default = []

--- a/src/asns.rs
+++ b/src/asns.rs
@@ -55,7 +55,7 @@ impl Asn {
 }
 
 pub struct Asns {
-    pub asns: BTreeSet<Asn>, // Make it public
+    pub asns: BTreeSet<Asn>,
 }
 
 impl Asns {
@@ -93,8 +93,6 @@ impl Asns {
                         .enable_http1()
                         .enable_http2()
                         .build();
-
-                    // This creates a temporary client - not ideal but maintains backward compatibility
                     &Client::builder(TokioExecutor::new()).build::<_, Empty<Bytes>>(https)
                 }
             };
@@ -204,7 +202,7 @@ impl Asns {
     }
 
     fn parse_data(bytes: Bytes) -> Result<Self, &'static str> {
-        // Use BufReader to stream line-by-line instead of reading entire file into String
+        // Use BufReader to stream line-by-line
         let decoder = GzDecoder::new(bytes.as_ref());
         let reader = BufReader::new(decoder);
 

--- a/src/asns.rs
+++ b/src/asns.rs
@@ -8,7 +8,7 @@ use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
 use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use std::collections::BTreeSet;
-use std::io::prelude::*;
+use std::io::{prelude::*, BufReader};
 use std::net::IpAddr;
 use std::ops::Bound::{Included, Unbounded};
 use std::str::FromStr;
@@ -55,13 +55,19 @@ impl Asn {
 }
 
 pub struct Asns {
-    asns: BTreeSet<Asn>,
+    pub asns: BTreeSet<Asn>, // Make it public
 }
 
 impl Asns {
-    pub async fn new(url: &str) -> Result<Self, &'static str> {
-        info!("Loading the database from {}", url);
-
+    pub async fn new(
+        url: &str,
+        http_client: Option<
+            &Client<
+                hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+                Empty<Bytes>,
+            >,
+        >,
+    ) -> Result<Self, &'static str> {
         let bytes = if url.starts_with("file://") {
             // Handle local file URL
             let path = url.trim_start_matches("file://");
@@ -77,17 +83,21 @@ impl Asns {
             // Handle HTTP or HTTPS URL
             info!("Loading the database from {}", url);
 
-            // Create an HTTPS connector with TLS 1.3 support
-            let https = HttpsConnectorBuilder::new()
-                .with_native_roots()
-                .expect("Failed to load native roots")
-                .https_or_http()
-                .enable_http1()
-                .enable_http2() // Enable HTTP/2 for better performance
-                .build();
+            let client = match http_client {
+                Some(c) => c,
+                None => {
+                    let https = HttpsConnectorBuilder::new()
+                        .with_native_roots()
+                        .expect("Failed to load native roots")
+                        .https_or_http()
+                        .enable_http1()
+                        .enable_http2()
+                        .build();
 
-            // Create a client with the HTTPS connector
-            let client = Client::builder(TokioExecutor::new()).build::<_, Empty<Bytes>>(https);
+                    // This creates a temporary client - not ideal but maintains backward compatibility
+                    &Client::builder(TokioExecutor::new()).build::<_, Empty<Bytes>>(https)
+                }
+            };
 
             // Create the request
             let req = Request::builder()
@@ -194,43 +204,63 @@ impl Asns {
     }
 
     fn parse_data(bytes: Bytes) -> Result<Self, &'static str> {
-        let mut data = String::new();
-        if GzDecoder::new(bytes.as_ref())
-            .read_to_string(&mut data)
-            .is_err()
-        {
-            error!("Unable to decompress the database");
-            return Err("Unable to decompress the database");
-        }
+        // Use BufReader to stream line-by-line instead of reading entire file into String
+        let decoder = GzDecoder::new(bytes.as_ref());
+        let reader = BufReader::new(decoder);
+
         let mut asns = BTreeSet::new();
-        for line in data.split_terminator('\n') {
+        let mut line_count = 0;
+        let mut error_count = 0;
+
+        for line_result in reader.lines() {
+            let line = match line_result {
+                Ok(l) => l,
+                Err(e) => {
+                    error!("Error reading line: {}", e);
+                    return Err("Unable to decompress the database");
+                }
+            };
+
             if line.trim().is_empty() {
                 continue;
             }
+
+            line_count += 1;
+
             let mut parts = line.split('\t');
             let first_ip = match parts.next().and_then(|s| IpAddr::from_str(s).ok()) {
                 Some(ip) => ip,
                 None => {
-                    warn!("Invalid IP address in line: {}", line);
+                    error_count += 1;
+                    if error_count <= 10 {
+                        warn!("Invalid first IP address in line {}: {}", line_count, line);
+                    }
                     continue;
                 }
             };
             let last_ip = match parts.next().and_then(|s| IpAddr::from_str(s).ok()) {
                 Some(ip) => ip,
                 None => {
-                    warn!("Invalid IP address in line: {}", line);
+                    error_count += 1;
+                    if error_count <= 10 {
+                        warn!("Invalid last IP address in line {}: {}", line_count, line);
+                    }
                     continue;
                 }
             };
             let number = match parts.next().and_then(|s| u32::from_str(s).ok()) {
                 Some(num) => num,
                 None => {
-                    warn!("Invalid ASN number in line: {}", line);
+                    error_count += 1;
+                    if error_count <= 10 {
+                        warn!("Invalid ASN number in line {}: {}", line_count, line);
+                    }
                     continue;
                 }
             };
             let country = parts.next().unwrap_or("").to_owned();
             let description = parts.next().unwrap_or("").to_owned();
+
             let asn = Asn {
                 first_ip,
                 last_ip,
@@ -240,7 +270,19 @@ impl Asns {
             };
             asns.insert(asn);
         }
-        info!("Database loaded with {} entries", asns.len());
+
+        if error_count > 10 {
+            warn!(
+                "Total of {} malformed lines encountered (showing first 10)",
+                error_count
+            );
+        }
+
+        info!(
+            "Database loaded with {} entries from {} lines",
+            asns.len(),
+            line_count
+        );
         Ok(Self { asns })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,10 @@
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 #[macro_use]
 extern crate horrorshow;
 #[macro_use]
@@ -9,6 +16,11 @@ mod webservice;
 use crate::asns::Asns;
 use crate::webservice::WebService;
 use clap::{Arg, Command};
+use http_body_util::Empty;
+use hyper::body::Bytes;
+use hyper_rustls::HttpsConnectorBuilder;
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioExecutor;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
@@ -58,11 +70,23 @@ async fn main() {
         }
     };
 
-    let asns = match get_asns(db_url).await {
+    let http_client = if db_url.starts_with("http://") || db_url.starts_with("https://") {
+        let https = HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .expect("Failed to load native roots")
+            .https_or_http()
+            .enable_http1()
+            .enable_http2()
+            .build();
+        Some(Client::builder(TokioExecutor::new()).build::<_, Empty<Bytes>>(https))
+    } else {
+        None
+    };
+
+    let asns = match get_asns(db_url, http_client.as_ref()).await {
         Ok(asns) => asns,
         Err(e) => {
             error!("Failed to load initial database: {e}");
-            error!("Application cannot start without initial data");
             return;
         }
     };
@@ -72,10 +96,11 @@ async fn main() {
     if refresh_delay > 0 {
         let asns_arc_t = asns_arc.clone();
         let db_url_t = db_url.clone();
+        let http_client_t = http_client.clone();
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(Duration::from_secs(refresh_delay * 60)).await;
-                update_asns(&asns_arc_t, &db_url_t).await;
+                update_asns(&asns_arc_t, &db_url_t, http_client_t.as_ref()).await;
             }
         });
         info!(
@@ -89,25 +114,50 @@ async fn main() {
     WebService::start(asns_arc, listen_addr).await;
 }
 
-async fn get_asns(db_url: &str) -> Result<Asns, &'static str> {
+async fn get_asns(
+    db_url: &str,
+    http_client: Option<
+        &Client<
+            hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+            Empty<Bytes>,
+        >,
+    >,
+) -> Result<Asns, &'static str> {
     info!("Retrieving ASNs");
-    let asns = Asns::new(db_url).await?;
+    let asns = Asns::new(db_url, http_client).await?;
     info!("ASNs loaded");
     Ok(asns)
 }
 
-async fn update_asns(asns_arc: &Arc<RwLock<Arc<Asns>>>, db_url: &str) {
-    info!("Attempting to update ASN database");
-    let asns = match get_asns(db_url).await {
-        Ok(asns) => asns,
+async fn update_asns(
+    asns_arc: &Arc<RwLock<Arc<Asns>>>,
+    db_url: &str,
+    http_client: Option<
+        &Client<
+            hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+            Empty<Bytes>,
+        >,
+    >,
+) {
+    {
+        let empty_asns = Arc::new(Asns {
+            asns: std::collections::BTreeSet::new(),
+        });
+        let mut guard = asns_arc.write().unwrap();
+        let old = std::mem::replace(&mut *guard, empty_asns);
+        drop(guard);
+        drop(old);
+    }
+
+    let new_asns = match get_asns(db_url, http_client).await {
+        Ok(asns) => Arc::new(asns),
         Err(e) => {
             warn!("Failed to update ASN database: {e}");
             warn!("Continuing with existing data");
             return;
         }
     };
-    let asns_arc_new = Arc::new(asns);
-    let mut asns_arc_w = asns_arc.write().unwrap();
-    *asns_arc_w = asns_arc_new;
+
+    *asns_arc.write().unwrap() = new_asns;
     info!("ASN database successfully updated");
 }

--- a/src/webservice.rs
+++ b/src/webservice.rs
@@ -272,6 +272,7 @@ impl WebService {
             }
         };
 
+        log::info!("Listening on {}", addr);
         log::info!("webservice ready");
 
         loop {

--- a/src/webservice.rs
+++ b/src/webservice.rs
@@ -231,11 +231,13 @@ impl WebService {
             Ok(ip) => ip,
         };
 
-        let asns = asns_arc.read().unwrap().clone();
+        let response = {
+            let asns_guard = asns_arc.read().unwrap();
 
-        let found = match asns.lookup_by_ip(ip) {
-            None => {
-                let response = IpLookupResponse {
+            let found = asns_guard.lookup_by_ip(ip);
+
+            match found {
+                None => IpLookupResponse {
                     ip: ip.to_string(),
                     announced: false,
                     first_ip: None,
@@ -243,20 +245,18 @@ impl WebService {
                     as_number: None,
                     as_country_code: None,
                     as_description: None,
-                };
-                return Ok(Self::output(&Self::accept_type(headers), &response));
+                },
+                Some(found) => IpLookupResponse {
+                    ip: ip.to_string(),
+                    announced: true,
+                    first_ip: Some(found.first_ip.to_string()),
+                    last_ip: Some(found.last_ip.to_string()),
+                    as_number: Some(found.number),
+                    as_country_code: Some(found.country.clone()),
+                    as_description: Some(found.description.clone()),
+                },
             }
-            Some(found) => found,
-        };
-
-        let response = IpLookupResponse {
-            ip: ip.to_string(),
-            announced: true,
-            first_ip: Some(found.first_ip.to_string()),
-            last_ip: Some(found.last_ip.to_string()),
-            as_number: Some(found.number),
-            as_country_code: Some(found.country.clone()),
-            as_description: Some(found.description.clone()),
+            // asns_guard (and read lock) dropped here
         };
 
         Ok(Self::output(&Self::accept_type(headers), &response))


### PR DESCRIPTION
While testing a client query tool for an extended amount of time, I noticed memory usage of iptoasn-webservice had become exceptionally higher than it began. Over the course of a few hours it had grown from ~160mb to over ~600mb. I swapped to a faster update frequency and noticed every database update the memory usage would go up approximately the amount of the initial memory usage and this would repeat consistently. 

This PR fixes a few things regarding memory usage and stabilizes memory usage to around ~350mb for extended periods of time. The primary issue was the HTTP client was being recreated upon every database update. Along the way to finding that, I found some smaller memory management fixes that also helped in small amounts.

A side by side comparison of this version with the original will show the memory usage difference after the 3rd or 4th database update. `cat /proc/$(pgrep -f iptoasn-webservice)/status | grep -E "Vm|Rss"` can be used to show precise memory changes after each update, but it's visible in a system monitor as well. The version in this PR should show memory usage drops periodically and maintain a steady range.

I'm not a Rust expert and I did use Claude to assist/troubleshoot, just for transparency.