### PR TITLE
Added Signal handling for SIGINT and SIGTERM

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ async fn main() {
     let http_client = if db_url.starts_with("http://") || db_url.starts_with("https://") {
         Some(reqwest::Client::new())
     } else {
+        error!("Unsuported format for database url. Use http:// or https://");
         None
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,6 @@ async fn main() {
         db_task = None
     }
     let web_handle = tokio::spawn(async move {
-        info!("Listening on {}", listen_addr);
         WebService::start(asns_arc, &listen_addr).await;
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,9 +51,16 @@ async fn main() {
         )
         .get_matches();
 
-    let db_url = matches.get_one::<String>("db_url").unwrap();
-    let listen_addr = matches.get_one::<String>("listen_addr").unwrap();
-    let refresh_delay = *matches.get_one::<u64>("refresh_delay").unwrap();
+    let db_url = matches
+        .get_one::<String>("db_url")
+        .expect("URL for DB file should be set");
+    let listen_addr = matches
+        .get_one::<String>("listen_addr")
+        .expect("Listen address should be specified")
+        .clone();
+    let refresh_delay = *matches
+        .get_one::<u64>("refresh_delay")
+        .expect("Refresh interval should be set");
 
     // Create HTTP client once if URL is HTTP/HTTPS
     let http_client = if db_url.starts_with("http://") || db_url.starts_with("https://") {

--- a/src/webservice.rs
+++ b/src/webservice.rs
@@ -39,7 +39,6 @@ struct IpLookupResponse {
     as_description: Option<String>,
 }
 
-
 impl IpLookupResponse {
     fn not_found(ip: String) -> Self {
         Self {
@@ -267,7 +266,7 @@ impl WebService {
         };
 
         log::info!("webservice ready");
-
+        log::info!("Listening on {}", listen_addr);
         loop {
             let (tcp, remote_addr) = match listener.accept().await {
                 Ok(conn) => conn,


### PR DESCRIPTION
Container now properly shutting down when SIGINT is received when running with  `docker run` or `docker compose up`
Eliminates memory leak when SIGTERM or SIGINT are sent to the running webservice
**Leak can still occur if webservice is interrupted during startup**
The changes only ensure that the Webservice and the db refresh are terminated on on SIGINT or SIGTERM